### PR TITLE
Use is-promise to check if objects are Promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"@discordjs/rest": "^0.1.0-canary.0",
 		"common-tags": "^1.8.0",
 		"discord-api-types": "^0.24.0",
+		"is-promise": "^4.0.0",
 		"require-all": "^3.0.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"@discordjs/rest": "^0.1.0-canary.0",
 		"common-tags": "^1.8.0",
 		"discord-api-types": "^0.24.0",
-		"is-promise": "^4.0.0",
+		"is-promise": "4.0.0",
 		"require-all": "^3.0.0"
 	},
 	"devDependencies": {

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -1,5 +1,6 @@
 const { escapeMarkdown } = require('../util');
 const { oneLine, stripIndents } = require('common-tags');
+const isPromise = require('is-promise');
 const ArgumentUnionType = require('../types/union');
 
 /** A fancy argument */
@@ -392,7 +393,7 @@ class Argument {
 	validate(val, msg, vmsg) {
 		const valid = this.validator ? this.validator(val, msg, this, vmsg) : this.type.validate(val, msg, this, vmsg);
 		if(!valid || typeof valid === 'string') return this.error || valid;
-		if(valid instanceof Promise) return valid.then(vld => !vld || typeof vld === 'string' ? this.error || vld : vld);
+		if(isPromise(valid)) return valid.then(vld => !vld || typeof vld === 'string' ? this.error || vld : vld);
 		return valid;
 	}
 

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -1,6 +1,7 @@
 const Context = require('./extensions/context');
 const { Message } = require('discord.js');
 const { escapeRegex } = require('./util');
+const isPromise = require('is-promise');
 
 /** Handles parsing messages and running commands from them */
 class CommandDispatcher {
@@ -203,7 +204,7 @@ class CommandDispatcher {
 				const valid = typeof inhibit.reason === 'string' && (
 					typeof inhibit.response === 'undefined' ||
 					inhibit.response === null ||
-					inhibit.response instanceof Promise ||
+					isPromise(inhibit.response) ||
 					inhibit.response instanceof Message
 				);
 				if(!valid) {


### PR DESCRIPTION
This adds support for alternative Promise implementations

Equivalent to the accepted and merged PR [#321 from the original discordjs/Commando repository](https://github.com/discordjs/Commando/pull/321). It appears this fork was made before that commit was merged in, and I still want it along with the discord.js v13 support this fork provides😄